### PR TITLE
Change /celeste/random-map random to be secure

### DIFF
--- a/src/main/java/ovh/maddie480/randomstuff/frontend/CelesteModSearchService.java
+++ b/src/main/java/ovh/maddie480/randomstuff/frontend/CelesteModSearchService.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.SecureRandom;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -36,6 +37,8 @@ public class CelesteModSearchService extends HttpServlet {
     private static final Logger log = LoggerFactory.getLogger(CelesteModSearchService.class);
 
     private static List<ModInfo> modDatabaseForSorting = Collections.emptyList();
+
+    private static final SecureRandom secureRandom = new SecureRandom();
     private Map<Integer, String> modCategories;
 
     private byte[] everestVersionsNoNative;
@@ -72,7 +75,7 @@ public class CelesteModSearchService extends HttpServlet {
                     .toList();
 
             // pick a map and redirect to it. that's it.
-            ModInfo drawnMod = maps.get((int) (Math.random() * maps.size()));
+            ModInfo drawnMod = maps.get(secureRandom.nextInt(maps.size()));
             response.setStatus(302);
             response.setHeader("Location", "https://gamebanana.com/mods/" + drawnMod.id);
             return;

--- a/src/main/java/ovh/maddie480/randomstuff/frontend/CelesteModSearchService.java
+++ b/src/main/java/ovh/maddie480/randomstuff/frontend/CelesteModSearchService.java
@@ -38,13 +38,14 @@ public class CelesteModSearchService extends HttpServlet {
 
     private static List<ModInfo> modDatabaseForSorting = Collections.emptyList();
 
-    private static final SecureRandom secureRandom = new SecureRandom();
     private Map<Integer, String> modCategories;
 
     private byte[] everestVersionsNoNative;
     private byte[] everestVersionsWithNative;
 
     private static final Pattern SUPPORT_NATIVE_REGEX = Pattern.compile("(^|&)supportsNativeBuilds=true($|&)");
+
+    private static final SecureRandom secureRandom = new SecureRandom();
 
     @Override
     public void init() {

--- a/src/main/java/ovh/maddie480/randomstuff/frontend/CelesteModSearchService.java
+++ b/src/main/java/ovh/maddie480/randomstuff/frontend/CelesteModSearchService.java
@@ -37,7 +37,6 @@ public class CelesteModSearchService extends HttpServlet {
     private static final Logger log = LoggerFactory.getLogger(CelesteModSearchService.class);
 
     private static List<ModInfo> modDatabaseForSorting = Collections.emptyList();
-
     private Map<Integer, String> modCategories;
 
     private byte[] everestVersionsNoNative;


### PR DESCRIPTION
Very very minor and silly thing, but replaces the `Math.random()` call with a `SecureRandom` call as currently it should be theoretically possible to eventually predict outputs from it (it'd be a lot of work though).

It also uses `nextInt` as that should also just be uniform.

I have not tested this but it should work.